### PR TITLE
Debug bi directional streams and get them working

### DIFF
--- a/src/main/java/GameClients.java
+++ b/src/main/java/GameClients.java
@@ -1,27 +1,59 @@
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GameClients {
   private static final Logger logger = LoggerFactory.getLogger(GameClients.class);
-  private static final List<GameClient> clients = Collections.synchronizedList(new ArrayList<>());
+  private static final Map<Integer, GameClient> clientsMap =
+      Collections.synchronizedMap(new HashMap<>());
 
   GameClients() throws InterruptedException {
-    for (int x = 0; x < GameServerAndGameClients.MAX_PLAYERS; x++) {
+    for (int x = 1; x <= GameServerAndGameClients.MAX_PLAYERS; x++) {
       logger.info(
           "Attempting to create {} of {} GameClient instances",
           x,
           GameServerAndGameClients.MAX_PLAYERS);
       GameClient newClient = new GameClient("localhost", GameServer.PORT);
-      newClient.startGame();
+      newClient.startGame(x);
       logger.info("Successfully called .startGame() for GameClient {}", x);
-      clients.add(newClient);
+      clientsMap.put(x, newClient);
     }
   }
 
-  public List<GameClient> getClients() {
-    return clients;
+  //  public void createAndStartGameClients() {
+  //    int numClients = GameServerAndGameClients.MAX_PLAYERS;
+  //    ExecutorService executor = Executors.newFixedThreadPool(numClients); // Create a thread pool
+  //
+  //    for (int x = 1; x <= numClients; x++) {
+  //      final int clientId = x; // Effectively final for use in lambda
+  //      executor.submit(() -> {
+  //        logger.info("Attempting to create {} of {} GameClient instances", clientId, numClients);
+  //        try {
+  //          GameClient newClient = new GameClient("localhost", GameServer.PORT);
+  //          newClient.startGame(clientId);
+  //          logger.info("Successfully called .startGame() for GameClient {}", clientId);
+  //          clients.add(newClient);
+  //        } catch (Exception e) {
+  //          logger.error("Error creating or starting GameClient {}", clientId, e);
+  //        }
+  //      });
+  //    }
+  //
+  //    executor.shutdown(); // No new tasks will be accepted
+  //    try {
+  //      // Wait for all tasks to finish execution or timeout after a certain period
+  //      if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+  //        logger.warn("Some tasks did not finish before the timeout");
+  //      }
+  //    } catch (InterruptedException e) {
+  //      logger.error("Interrupted while waiting for game clients to start", e);
+  //      Thread.currentThread().interrupt();
+  //    }
+  //  }
+
+  public Map<Integer, GameClient> getClients() {
+    return clientsMap;
   }
 }

--- a/src/main/java/GameClients.java
+++ b/src/main/java/GameClients.java
@@ -6,16 +6,17 @@ import org.slf4j.LoggerFactory;
 
 public class GameClients {
   private static final Logger logger = LoggerFactory.getLogger(GameClients.class);
-
-  private static final int MAX_CLIENT_INSTANCES = 1;
-  //  private static final AtomicInteger firstClientPort = new AtomicInteger(GameServer.PORT);
   private static final List<GameClient> clients = Collections.synchronizedList(new ArrayList<>());
 
   GameClients() throws InterruptedException {
-    for (int x = 0; x < MAX_CLIENT_INSTANCES; x++) {
-      //      GameClient newClient = new GameClient("localhost", firstClientPort.addAndGet(1));
+    for (int x = 0; x < GameServerAndGameClients.MAX_PLAYERS; x++) {
+      logger.info(
+          "Attempting to create {} of {} GameClient instances",
+          x,
+          GameServerAndGameClients.MAX_PLAYERS);
       GameClient newClient = new GameClient("localhost", GameServer.PORT);
       newClient.startGame();
+      logger.info("Successfully called .startGame() for GameClient {}", x);
       clients.add(newClient);
     }
   }

--- a/src/main/java/GameServer.java
+++ b/src/main/java/GameServer.java
@@ -3,15 +3,14 @@ import game.GameService.GameState;
 import game.GameStateServiceGrpc;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GameServer {
   private io.grpc.Server grpcServer;
@@ -25,9 +24,7 @@ public class GameServer {
   private final Map<Integer, StreamObserver<GameState>> playerStateStreams =
       Collections.synchronizedMap(new HashMap<>(GameServerAndGameClients.MAX_PLAYERS));
 
-  /**
-   * A map of all of every individual player's state key'd off of the player's number.
-   */
+  /** A map of all of every individual player's state key'd off of the player's number. */
   private final Map<Integer, GameService.PlayerState> playerStates =
       Collections.synchronizedMap(new HashMap<>(GameServerAndGameClients.MAX_PLAYERS));
 
@@ -35,13 +32,28 @@ public class GameServer {
    * Records the number of players in the game. Increments to add new players to the game so they
    * can be tracked via their unique stream number / player state number.
    */
-  private final AtomicInteger playerCount = new AtomicInteger(0);
+  private final AtomicInteger playerCount = new AtomicInteger(1);
 
-  /**
-   * The global game state. Defaults to empty. TODO(Canavan): this probably needs a different
-   * constructor for initial state
-   */
-  private GameState gameState = GameState.newBuilder().build();
+  private GameService.PlayerState Player1State =
+      GameService.PlayerState.newBuilder().setNumber(1).setConnected(false).build();
+  private GameService.PlayerState Player2State =
+      GameService.PlayerState.newBuilder().setNumber(2).setConnected(false).build();
+  private GameService.PlayerState Player3State =
+      GameService.PlayerState.newBuilder().setNumber(3).setConnected(false).build();
+  private GameService.PlayerState Player4State =
+      GameService.PlayerState.newBuilder().setNumber(4).setConnected(false).build();
+  private GameService.PlayerState Player5State =
+      GameService.PlayerState.newBuilder().setNumber(5).setConnected(false).build();
+  private GameService.PlayerState Player6State =
+      GameService.PlayerState.newBuilder().setNumber(6).setConnected(false).build();
+  private GameService.PlayerState Player7State =
+      GameService.PlayerState.newBuilder().setNumber(7).setConnected(false).build();
+  private GameService.PlayerState Player8State =
+      GameService.PlayerState.newBuilder().setNumber(8).setConnected(false).build();
+  private GameService.PlayerState Player9State =
+      GameService.PlayerState.newBuilder().setNumber(9).setConnected(false).build();
+  private GameService.PlayerState Player10State =
+      GameService.PlayerState.newBuilder().setNumber(10).setConnected(false).build();
 
   public static void main(String[] args) throws IOException, InterruptedException {
     logger.info("[SERVER] main() called");
@@ -104,7 +116,7 @@ public class GameServer {
       logger.info("[SERVER] {} player state streams", playerStateStreams.keySet().size());
       logger.info("[SERVER] {} player states", playerStates.keySet().size());
 
-      // Return a new StreamObserver to handle incoming PlayerState messages from the client
+      // Generate a new Client Sender
       return new StreamObserver<>() {
         @Override
         public void onNext(GameService.PlayerState playerState) {
@@ -114,11 +126,57 @@ public class GameServer {
               playerState.getCoordinates().getX(),
               playerState.getCoordinates().getY(),
               playerState.getCoordinates().getZ());
-          // TODO(Canavan): make this multi-threaded safe
-          generateUpdatedGameState(playerState);
+
+          switch (playerState.getNumber()) {
+            case 1:
+              Player1State = playerState;
+              break;
+            case 2:
+              Player2State = playerState;
+              break;
+            case 3:
+              Player3State = playerState;
+              break;
+            case 4:
+              Player4State = playerState;
+              break;
+            case 5:
+              Player5State = playerState;
+              break;
+            case 6:
+              Player6State = playerState;
+              break;
+            case 7:
+              Player7State = playerState;
+              break;
+            case 8:
+              Player8State = playerState;
+              break;
+            case 9:
+              Player9State = playerState;
+              break;
+            case 10:
+              Player10State = playerState;
+              break;
+          }
+
+          GameState gameState =
+              GameState.newBuilder()
+                  .setPlayer1(Player1State)
+                  .setPlayer2(Player2State)
+                  .setPlayer3(Player3State)
+                  .setPlayer4(Player4State)
+                  .setPlayer5(Player5State)
+                  .setPlayer6(Player6State)
+                  .setPlayer7(Player7State)
+                  .setPlayer8(Player8State)
+                  .setPlayer9(Player9State)
+                  .setPlayer10(Player10State)
+                  .build();
+
           // Then, broadcast the updated GameState to all connected players
           for (Integer x : playerStateStreams.keySet()) {
-            logger.info("[SERVER][SEND] PID {} GameState {}", x, gameState);
+            logger.info("[SERVER][SEND] GameState {} to PID {}", gameState, x);
             playerStateStreams.get(x).onNext(gameState);
           }
         }
@@ -139,32 +197,6 @@ public class GameServer {
           playerStates.put(playerNumber, null);
         }
       };
-    }
-
-    // Utility method to generate the updated GameState based on the received PlayerState
-    // This needs to be implemented according to your specific game logic
-    private void generateUpdatedGameState(GameService.PlayerState playerState) {
-      if (playerState.getNumber() == 1) {
-        gameState = GameState.newBuilder(gameState).setPlayer1(playerState).build();
-      } else if (playerState.getNumber() == 2) {
-        gameState = GameState.newBuilder(gameState).setPlayer2(playerState).build();
-      } else if (playerState.getNumber() == 3) {
-        gameState = GameState.newBuilder(gameState).setPlayer3(playerState).build();
-      } else if (playerState.getNumber() == 4) {
-        gameState = GameState.newBuilder(gameState).setPlayer4(playerState).build();
-      } else if (playerState.getNumber() == 5) {
-        gameState = GameState.newBuilder(gameState).setPlayer5(playerState).build();
-      } else if (playerState.getNumber() == 6) {
-        gameState = GameState.newBuilder(gameState).setPlayer6(playerState).build();
-      } else if (playerState.getNumber() == 7) {
-        gameState = GameState.newBuilder(gameState).setPlayer7(playerState).build();
-      } else if (playerState.getNumber() == 8) {
-        gameState = GameState.newBuilder(gameState).setPlayer8(playerState).build();
-      } else if (playerState.getNumber() == 9) {
-        gameState = GameState.newBuilder(gameState).setPlayer9(playerState).build();
-      } else if (playerState.getNumber() == 10) {
-        gameState = GameState.newBuilder(gameState).setPlayer10(playerState).build();
-      }
     }
   }
 }

--- a/src/main/java/GameServerAndGameClients.java
+++ b/src/main/java/GameServerAndGameClients.java
@@ -1,12 +1,12 @@
 import game.GameService;
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GameServerAndGameClients {
-  public static final int MAX_PLAYERS = 1;
+  public static final int MAX_PLAYERS = 2;
   public static final int MAX_POS = 1000;
   public static final int MAX_MOVES = 2;
   private static final Logger logger = LoggerFactory.getLogger(GameServerAndGameClients.class);
@@ -23,9 +23,9 @@ public class GameServerAndGameClients {
       logger.info("Initializing GameClients");
       GameClients gameClients = new GameClients();
       Thread.sleep(10000);
-      List<GameClient> clientsList = gameClients.getClients();
+      Map<Integer, GameClient> clientsMap = gameClients.getClients();
       // shutdown the game first
-      clientsList.get(0).shutdown();
+      clientsMap.get(1).shutdown();
       gameServer.stop();
     } catch (InterruptedException | IOException e) {
       e.printStackTrace();
@@ -35,10 +35,10 @@ public class GameServerAndGameClients {
     logger.info("end of main reached");
   }
 
-  public static GameService.PlayerState getDefaultState() {
+  public static GameService.PlayerState getDefaultState(int playerNumber) {
     return GameService.PlayerState.newBuilder()
         .setConnected(true)
-        .setNumber(0)
+        .setNumber(playerNumber)
         .setCoordinates(
             GameService.Coordinates.newBuilder()
                 .setX(getRandomMiddleCoordinates())

--- a/src/main/java/GameServerAndGameClients.java
+++ b/src/main/java/GameServerAndGameClients.java
@@ -6,9 +6,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GameServerAndGameClients {
-  public static final int MAX_PLAYERS = 10;
+  public static final int MAX_PLAYERS = 1;
   public static final int MAX_POS = 1000;
-  public static final int MAX_MOVES = 100;
+  public static final int MAX_MOVES = 2;
   private static final Logger logger = LoggerFactory.getLogger(GameServerAndGameClients.class);
   private static final Random random = new Random();
 
@@ -39,7 +39,12 @@ public class GameServerAndGameClients {
     return GameService.PlayerState.newBuilder()
         .setConnected(true)
         .setNumber(0)
-        .setCoordinates(GameService.Coordinates.newBuilder().setX(0).setY(0).setZ(0).build())
+        .setCoordinates(
+            GameService.Coordinates.newBuilder()
+                .setX(getRandomMiddleCoordinates())
+                .setY(getRandomMiddleCoordinates())
+                .setZ(getRandomMiddleCoordinates())
+                .build())
         .build();
   }
 
@@ -50,27 +55,13 @@ public class GameServerAndGameClients {
   }
 
   public static GameService.Coordinates doRandomMovement(GameService.Coordinates coordinates) {
-    int x = coordinates.getX();
-    int y = coordinates.getY();
-    int z = coordinates.getZ();
-
-    // handle the default state where the player starts at 0, 0, 0
-    if (x == 0 && y == 0 && z == 0) {
-      logger.info("Detected 0, 0, 0. Returning middle-ish coordinates");
-      return GameService.Coordinates.newBuilder()
-          .setX(getRandomMiddleCoordinates())
-          .setY(getRandomMiddleCoordinates())
-          .setZ(getRandomMiddleCoordinates())
-          .build();
-    }
-
     // Otherwise, randomly nudge the player along the X, Y, and Z axis by 5
     // Unless that would put the player out of bounds, then correct by moving 100 in the other
     // direction
     return GameService.Coordinates.newBuilder()
-        .setX(playerMoves(x))
-        .setY(playerMoves(y))
-        .setZ(playerMoves(z))
+        .setX(playerMoves(coordinates.getX()))
+        .setY(playerMoves(coordinates.getY()))
+        .setZ(playerMoves(coordinates.getZ()))
         .build();
   }
 


### PR DESCRIPTION
* accept a playerNumber for startGame() so clients know which number they are and can set their default state accordingly
* add playerNumber to all client-side logs
* reduce delay in-between successive requests
* better logs across the board
* do not store global game state - instead just the state for each player and build the state at the last second when sending out
* use a map for storing all of the clients
* simplify default coordinates / player state creation