### PR TITLE
Crank it up to 11

### DIFF
--- a/logback.xml
+++ b/logback.xml
@@ -8,4 +8,9 @@
     <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>
+
+    <!-- Increase logging level for gRPC to TRACE -->
+    <logger name="io.grpc" level="TRACE" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
 </configuration>

--- a/src/main/java/GameClient.java
+++ b/src/main/java/GameClient.java
@@ -61,7 +61,7 @@ public class GameClient extends LoggableState implements StreamObserver<GameServ
 
     // Optionally join the thread to ensure it has finished
     try {
-      sendingThread.join(); // Wait for the printing thread to finish
+      sendingThread.join(5000); // Wait for the printing thread to finish
       channel.shutdown().awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       logger.error("Interrupted while waiting for the printing thread to finish", e);

--- a/src/main/java/GameClient.java
+++ b/src/main/java/GameClient.java
@@ -34,23 +34,12 @@ public class GameClient extends LoggableState implements StreamObserver<GameServ
   public void onError(Throwable t) {
     logger.error("[CLIENT][RECEIVE][{}] ERROR {}", playerNumber, t.toString());
     t.printStackTrace();
-    //    try {
     stop();
-    //    } catch (InterruptedException e) {
-    //      logger.error("[CLIENT][EXCEPTION][{}] ERROR {}", playerNumber, e.toString());
-    //    }
   }
 
   @Override
   public void onCompleted() {
-    logger.info("[CLIENT][RECEIVE][{}] COMPLETED", playerNumber);
-    //    try {
-    stop();
-    logger.info("[CLIENT][{}] shutdown() success", playerNumber);
-    //    } catch (InterruptedException e) {
-    //      logger.error("[CLIENT][EXCEPTION][{}] ERROR {}", playerNumber, e.toString());
-    //      e.printStackTrace();
-    //    }
+    logger.info("[CLIENT][{}] onCompleted() success", playerNumber);
   }
 
   public void stop() {
@@ -61,8 +50,13 @@ public class GameClient extends LoggableState implements StreamObserver<GameServ
 
     // Optionally join the thread to ensure it has finished
     try {
+      logger.info("[CLIENT][STOP][{}] about to call sendingThread.join()", playerNumber);
       sendingThread.join(5000); // Wait for the printing thread to finish
+      logger.info("[CLIENT][STOP][{}] about to call channel.shutdown", playerNumber);
+      // send a close request from the client to the server to close the bi-directional stream
+      this.requestObserver.onCompleted();
       channel.shutdown().awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
+      logger.info("[CLIENT][STOP][{}] successfully stopped", playerNumber);
     } catch (InterruptedException e) {
       logger.error("Interrupted while waiting for the printing thread to finish", e);
       Thread.currentThread().interrupt(); // Restore interrupted status

--- a/src/main/java/GameServer.java
+++ b/src/main/java/GameServer.java
@@ -109,6 +109,7 @@ public class GameServer extends LoggableState {
     grpcServer.shutdown();
     logger.info("[SERVER][STOP] successfully called shutdown() - about to call awaitTermination()");
     grpcServer.awaitTermination(5, SECONDS);
+    grpcServer.shutdownNow();
     grpcServer = null;
     logger.info("[SERVER] grpcServer.shutdown() success");
   }

--- a/src/main/java/GameServerAndGameClients.java
+++ b/src/main/java/GameServerAndGameClients.java
@@ -40,7 +40,7 @@ public class GameServerAndGameClients {
 
       long millis = 5000;
       logger.info("main is sleeping for {} millis", millis);
-      Thread.sleep(millis); // sleep for 30 seconds
+      Thread.sleep(millis); // sleep to let clients send messages
       logger.info("main is done sleeping for {} millis", millis);
       logger.info("clientsMap.keySet().size() {}", clientsMap.keySet().size());
       // Stop sending on all game clients and stop logging
@@ -55,7 +55,8 @@ public class GameServerAndGameClients {
                 currentClient.stopLogging();
                 logger.info("[CLIENT][STOP][{}] stopLogging() success", key);
               });
-      //      gameServer.stopLogging();
+      Thread.sleep(3000);
+      gameServer.stopLogging();
       gameServer.stop();
     } catch (InterruptedException | IOException e) {
       e.printStackTrace();

--- a/src/main/java/GameServerAndGameClients.java
+++ b/src/main/java/GameServerAndGameClients.java
@@ -1,14 +1,15 @@
 import game.GameService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GameServerAndGameClients {
-  public static final int MAX_PLAYERS = 2;
+  public static final int MAX_PLAYERS = 10;
   public static final int MAX_POS = 1000;
   private static final Logger logger = LoggerFactory.getLogger(GameServerAndGameClients.class);
   private static final Random random = new Random();
@@ -20,19 +21,19 @@ public class GameServerAndGameClients {
 
     try {
       gameServer.start();
-      //      gameServer.startLogging();
+      gameServer.startLogging();
       logger.info("Successfully started GameServer");
       for (int playerNumber = 1;
-          playerNumber <= GameServerAndGameClients.MAX_PLAYERS;
-          playerNumber++) {
+           playerNumber <= GameServerAndGameClients.MAX_PLAYERS;
+           playerNumber++) {
         logger.info(
             "Attempting to create {} of {} GameClient instances",
             playerNumber,
             GameServerAndGameClients.MAX_PLAYERS);
         GameClient newClient = new GameClient("localhost", GameServer.PORT, playerNumber);
-        // initialize logging the game state
-        //        newClient.startLogging();
-        // initialize sending of randomized local player state to the server
+        //         initialize logging the game state
+        newClient.startLogging();
+        //         initialize sending of randomized local player state to the server
         newClient.start();
         clientsMap.put(playerNumber, newClient);
       }

--- a/src/main/java/LoggableState.java
+++ b/src/main/java/LoggableState.java
@@ -41,14 +41,20 @@ public abstract class LoggableState extends GameState {
   }
 
   public synchronized void stopLogging() {
+    logger.info("[{}][{}] stopLogging called", type, playerNumber);
     setLoggingEnabled(false);
+    logger.info("[{}][{}] setLoggingEnabled(false)", type, playerNumber);
     if (printThread == null) {
+      logger.info("[{}][{}] printThread == null - returning", type, playerNumber);
       return;
     }
 
     // Optionally join the thread to ensure it has finished
     try {
-      printThread.join(); // Wait for the printing thread to finish
+      logger.info("[{}][{}] about to call printThread.join(5000)", type, playerNumber);
+      printThread.join(5000); // Wait for the printing thread to finish
+      printThread.interrupt();
+      logger.info("[{}][{}] successfully called printThread.join(5000)", type, playerNumber);
     } catch (InterruptedException e) {
       logger.error("Interrupted while waiting for the printing thread to finish", e);
       Thread.currentThread().interrupt(); // Restore interrupted status


### PR DESCRIPTION
* change the number of players from 1 to 10
* increase GRPC logging from DEBUG to TRACE
* move logic from onCompleted() to stop(). this prevents a double shutdown as well as correctly closes the client connection. the GRPC library internally makes the call to close the bi-directional stream
* move executor pool to the class level so that it can be gracefully closed during server stop() (fixes deadlock on shutdown)
* add check for game server onNext() to see if the current thread is interrupted. if so, return. although i don't think this is necessary. 
* add null check when retrieving a stream before sending a message over that stream. this fixes a race condition where the stream is closed on onCompleted() but there's a message still being processed
* add join(5000) call to logging thread. this fixes a deadlock issue on shutdown where the thread would never close